### PR TITLE
Fix build error in Unreal 4.24

### DIFF
--- a/Source/NdiMedia/Private/Ndi/Ndi.h
+++ b/Source/NdiMedia/Private/Ndi/Ndi.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-struct NDIlib_v3;
-
+#include "Processing.NDI.Lib.h"
 
 class FNdi
 {

--- a/Source/NdiMediaEditor/NdiMediaEditor.Build.cs
+++ b/Source/NdiMediaEditor/NdiMediaEditor.Build.cs
@@ -11,6 +11,7 @@ namespace UnrealBuildTool.Rules
 			PrivateDependencyModuleNames.AddRange(
 				new string[] {
 					"Core",
+					"Engine",
 					"CoreUObject",
 					"MediaAssets",
 					"NdiMedia",


### PR DESCRIPTION
* Add explicit `Engine` module dependency so NDI plugin will build in UE4 versions after 4.23.
* Remove forward declaration of NDIlib_v3 struct so NDI SDK v4 can also be used with the plugin.